### PR TITLE
Add "BlueJeans" keyword

### DIFF
--- a/com.bluejeans.BlueJeans.desktop
+++ b/com.bluejeans.BlueJeans.desktop
@@ -7,3 +7,4 @@ Type=Application
 Icon=com.bluejeans.BlueJeans
 Categories=Network;VideoConference;
 MimeType=x-scheme-handler/bjn;
+Keywords=BlueJeans;


### PR DESCRIPTION
Searching GNOME Software (3.26) or the GNOME Shell (3.32) desktop search
for "bluejeans" does not find this app. This one-word version of the
brand only appears in the app ID, icon name and executable line.

Shell uses GLib's g_desktop_app_info_search() which does look at Exec=,
but only the first component of the command-line – sensible in a
pre-Flatpak era but useless for Flatpaks whose first component is always
`flatpak`.

You could reasonably argue that GNOME Software should include app IDs in
the search keys, and that GLib should do the same, but for now we can
achieve the same effect by adding a keyword to the .desktop file. It
will be merged into the appstream at build time, I think.