### PR TITLE
Quiet down log spam

### DIFF
--- a/com.bluejeans.BlueJeans.yaml
+++ b/com.bluejeans.BlueJeans.yaml
@@ -70,7 +70,7 @@ modules:
         commands:
           - "[ -d /var/home ] && unlink /home && mv /var/home /home"
           - "export LD_LIBRARY_PATH=/app/lib"
-          - "exec /app/extra/bluejeans $@"
+          - "exec /app/extra/bluejeans $@ 2>&1 | grep -v :INFO:"
     build-commands:
       - install -D apply_extra /app/bin/apply_extra
       - install -D bluejeans /app/bin/bluejeans


### PR DESCRIPTION
Fix the incessant log spam by the Bluejeans app:
Mar 16 16:03:37 classic com.bluejeans.BlueJeans.desktop[355213]: [2:0316/160337:INFO:shell_content_browser_plugin.cc(53)] Allowing plugin: bjnplugin : /home/hadess/.config/Blue Jeans/desktop/execdir/package.nw/plugins/npbjnplugin_3.0.6.5.so

Closes: #7