### PR TITLE
Use same update page as the desktop client itself

### DIFF
--- a/com.bluejeans.BlueJeans.appdata.xml
+++ b/com.bluejeans.BlueJeans.appdata.xml
@@ -35,6 +35,7 @@
     <content_attribute id="social-audio">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="2.24.0.89" date="2021-09-03"/>
     <release version="2.23.0.39" date="2021-06-25"/>
     <release version="2.22.0.87" date="2021-05-11"/>
     <release version="2.21.3.2" date="2021-03-09"/>

--- a/com.bluejeans.BlueJeans.yaml
+++ b/com.bluejeans.BlueJeans.yaml
@@ -77,11 +77,9 @@ modules:
         size: 83226268
         x-checker-data:
           type: html
-          url: https://www.bluejeans.com/downloads
-          version-pattern: <a href="https://swdl.bluejeans.com/desktop-app/linux/[\d\.-]*/BlueJeans_([\d\.-]*).rpm"
-            class="Button" aria-label="Download BlueJeans for Linux">
-          url-pattern: <a href="(https://swdl.bluejeans.com/desktop-app/linux/[\d\.-]*/BlueJeans_[\d\.-]*.rpm)"
-            class="Button" aria-label="Download BlueJeans for Linux">
+          url: https://swdl.bluejeans.com/desktop-app/linux/ga.manifest.json
+          version-pattern: \"https://swdl.bluejeans.com/desktop-app/linux/[\d\.-]*/BlueJeans_([\d\.-]*).rpm\"
+          url-pattern: \"(https://swdl.bluejeans.com/desktop-app/linux/[\d\.-]*/BlueJeans_[\d\.-]*.rpm)\"
           only-arches: [x86_64]
       - type: script
         dest-filename: apply_extra

--- a/com.bluejeans.BlueJeans.yaml
+++ b/com.bluejeans.BlueJeans.yaml
@@ -72,9 +72,9 @@ modules:
         path: com.bluejeans.BlueJeans-96x96.png
       - type: extra-data
         filename: bluejeans.rpm
-        url: https://swdl.bluejeans.com/desktop-app/linux/2.23.0/BlueJeans_2.23.0.39.rpm
-        sha256: 2c6835e0a27f8449d2692add4e5b58f585efecd7a491fa3aeae2e4c63331f002
-        size: 83226268
+        url: https://swdl.bluejeans.com/desktop-app/linux/2.24.0/BlueJeans_2.24.0.89.rpm
+        sha256: ae7797f32b3fa0a7d52dabc0664e51268b8e66456ca7ef4120045e49e6222897
+        size: 85437528
         x-checker-data:
           type: html
           url: https://swdl.bluejeans.com/desktop-app/linux/ga.manifest.json


### PR DESCRIPTION
So that we don't see update dialogues when launching BlueJeans...